### PR TITLE
Clarify uv init vs requirements usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,18 +23,18 @@ It is recommended to use a Python virtual environment to isolate project depende
 
 ### 1. Create and activate a virtual environment
 
-**macOS/Linux:**
+If you want uv to manage Python + virtual environments:
+
+```bash
+uv venv
+source .venv/bin/activate  # On Windows: .venv\\Scripts\\activate
+```
+
+If you prefer the standard Python tooling:
 
 ```bash
 python3 -m venv venv
-source venv/bin/activate
-```
-
-**Windows:**
-
-```bash
-python -m venv venv
-venv\Scripts\activate
+source venv/bin/activate  # On Windows: venv\\Scripts\\activate
 ```
 
 ### 2. Install dependencies
@@ -42,14 +42,21 @@ venv\Scripts\activate
 To run the main functionality:
 
 ```bash
-pip install -r requirements.txt
+uv pip install -r requirements.txt
 ```
 
 To install test dependencies only:
 
 ```bash
-pip install -r requirements-test.txt
+uv pip install -r requirements-test.txt
 ```
+
+> Notes:
+> - `uv pip` is a drop-in replacement for `pip` that runs via uv.
+> - `uv init` is for bootstrapping a **new** uv-managed project (creates
+>   `pyproject.toml`/`uv.lock`). This repo already uses `requirements.txt`, so
+>   `uv pip install -r ...` is the compatible path unless you migrate to uv
+>   project files.
 
 ---
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,11 +6,21 @@
 
 ## 安裝測試相依套件
 
-請使用獨立的測試依賴檔案：
+請使用獨立的測試依賴檔案（若使用 uv 管理環境，先建立 venv）：
 
 ```bash
-pip install -r requirements-test.txt
+uv venv
+source .venv/bin/activate  # Windows: .venv\\Scripts\\activate
 ```
+
+再安裝測試依賴：
+
+```bash
+uv pip install -r requirements-test.txt
+```
+
+> 補充：`uv init` 主要用於初始化新專案（建立 `pyproject.toml`/`uv.lock`）。
+> 本專案維持 `requirements-test.txt`，因此用 `uv pip install -r ...` 即可。
 
 `requirements-test.txt` 應包含：
 


### PR DESCRIPTION
### Motivation
- Clarify whether `uv init` is required and explain how `uv venv`/`uv pip` relate to the repo's existing `requirements.txt` workflow due to reviewer confusion.

### Description
- Updated `README.md` to show `uv venv` + `source .venv/bin/activate` and the alternative `python3 -m venv` instructions, and replaced `pip install` examples with `uv pip install -r ...`.
- Added a short note in `README.md` that `uv pip` is a drop-in replacement for `pip` and that `uv init` bootstraps new uv-managed projects (producing `pyproject.toml`/`uv.lock`), while this repo remains `requirements.txt`-based.
- Updated `TESTING.md` to add `uv venv` activation steps, switch test dependency installs to `uv pip install -r requirements-test.txt`, and include the same clarification about `uv init` vs keeping `requirements-test.txt`.
- Addressed inline comments asking whether `uv` replaces `venv`/`requirements.txt` by explicitly stating the compatible paths for this repository.

### Testing
- No automated tests were run because these are documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69893fd75cac832dbc44f4ab33dc1e24)