### PR TITLE
Guard data structure usage examples under __main__

### DIFF
--- a/DataStructures/binary_search_tree.py
+++ b/DataStructures/binary_search_tree.py
@@ -94,19 +94,20 @@ class BinarySearchTree:
         return res
 
 
-# Usage example
-bst = BinarySearchTree()
-bst.insert(5)
-bst.insert(3)
-bst.insert(7)
-bst.insert(2)
-bst.insert(4)
-bst.insert(6)
-bst.insert(8)
+if __name__ == "__main__":
+    # Usage example
+    bst = BinarySearchTree()
+    bst.insert(5)
+    bst.insert(3)
+    bst.insert(7)
+    bst.insert(2)
+    bst.insert(4)
+    bst.insert(6)
+    bst.insert(8)
 
-print("Inorder traversal:", bst.inorder_traversal())
-print("Preorder traversal:", bst.preorder_traversal())
-print("Postorder traversal:", bst.postorder_traversal())
-print("Search for 4:", bst.search(4))
-bst.delete(7)
-print("Inorder traversal after deleting 7:", bst.inorder_traversal())
+    print("Inorder traversal:", bst.inorder_traversal())
+    print("Preorder traversal:", bst.preorder_traversal())
+    print("Postorder traversal:", bst.postorder_traversal())
+    print("Search for 4:", bst.search(4))
+    bst.delete(7)
+    print("Inorder traversal after deleting 7:", bst.inorder_traversal())

--- a/DataStructures/binary_tree.py
+++ b/DataStructures/binary_tree.py
@@ -59,15 +59,16 @@ class BinaryTree:
         return res
 
 
-# Usage example
-binary_tree = BinaryTree()
-root = TreeNode(1)
-binary_tree.root = root
-binary_tree.insert_left(root, 2)
-binary_tree.insert_right(root, 3)
-binary_tree.insert_left(root.left, 4)
-binary_tree.insert_right(root.right, 5)
+if __name__ == "__main__":
+    # Usage example
+    binary_tree = BinaryTree()
+    root = TreeNode(1)
+    binary_tree.root = root
+    binary_tree.insert_left(root, 2)
+    binary_tree.insert_right(root, 3)
+    binary_tree.insert_left(root.left, 4)
+    binary_tree.insert_right(root.right, 5)
 
-print("Inorder traversal:", binary_tree.inorder_traversal())
-print("Preorder traversal:", binary_tree.preorder_traversal())
-print("Postorder traversal:", binary_tree.postorder_traversal())
+    print("Inorder traversal:", binary_tree.inorder_traversal())
+    print("Preorder traversal:", binary_tree.preorder_traversal())
+    print("Postorder traversal:", binary_tree.postorder_traversal())

--- a/DataStructures/deque_based_queue.py
+++ b/DataStructures/deque_based_queue.py
@@ -44,14 +44,15 @@ class Queue:
         return None
 
 
-# Usage example
-queue = Queue()
-queue.enqueue(1)
-queue.enqueue(2)
-queue.enqueue(3)
-print("Front item:", queue.peek())  # Output should be 1
-print("Queue size:", queue.size())  # Output should be 3
-dequeued_item = queue.dequeue()  # Should dequeue 1
-print("Dequeued item:", dequeued_item)
-print("New front item:", queue.peek())  # Output should be 2
-print("New queue size:", queue.size())  # Output should be 2
+if __name__ == "__main__":
+    # Usage example
+    queue = Queue()
+    queue.enqueue(1)
+    queue.enqueue(2)
+    queue.enqueue(3)
+    print("Front item:", queue.peek())  # Output should be 1
+    print("Queue size:", queue.size())  # Output should be 3
+    dequeued_item = queue.dequeue()  # Should dequeue 1
+    print("Dequeued item:", dequeued_item)
+    print("New front item:", queue.peek())  # Output should be 2
+    print("New queue size:", queue.size())  # Output should be 2

--- a/DataStructures/doubly_linked_list.py
+++ b/DataStructures/doubly_linked_list.py
@@ -74,15 +74,16 @@ class DoublyLinkedList:
         return elements
 
 
-# Usage example
-dll = DoublyLinkedList()
-dll.append(1)
-dll.append(2)
-dll.append(3)
-print("Forward:", dll.display_forward())  # Output: [1, 2, 3]
-print("Backward:", dll.display_backward())  # Output: [3, 2, 1]
+if __name__ == "__main__":
+    # Usage example
+    dll = DoublyLinkedList()
+    dll.append(1)
+    dll.append(2)
+    dll.append(3)
+    print("Forward:", dll.display_forward())  # Output: [1, 2, 3]
+    print("Backward:", dll.display_backward())  # Output: [3, 2, 1]
 
-node = dll.find(2)
-if node:
-    dll.delete(node)
-print("Forward after deletion:", dll.display_forward())  # Output: [1, 3]
+    node = dll.find(2)
+    if node:
+        dll.delete(node)
+    print("Forward after deletion:", dll.display_forward())  # Output: [1, 3]

--- a/DataStructures/list_based_stack.py
+++ b/DataStructures/list_based_stack.py
@@ -46,13 +46,14 @@ class Stack:
         return list(reversed(self.items))  # Display from top to bottom
 
 
-# Usage example
-stack = Stack()
-stack.push(1)
-stack.push(2)
-stack.push(3)
-print("Current Stack:", stack.display())  # Output should be [3, 2, 1]
-print("Top item:", stack.peek())  # Output should be 3
-popped_item = stack.pop()  # Should pop 3
-print("Popped item:", popped_item)
-print("Stack after pop:", stack.display())  # Output should be [2, 1]
+if __name__ == "__main__":
+    # Usage example
+    stack = Stack()
+    stack.push(1)
+    stack.push(2)
+    stack.push(3)
+    print("Current Stack:", stack.display())  # Output should be [3, 2, 1]
+    print("Top item:", stack.peek())  # Output should be 3
+    popped_item = stack.pop()  # Should pop 3
+    print("Popped item:", popped_item)
+    print("Stack after pop:", stack.display())  # Output should be [2, 1]

--- a/DataStructures/singly_linked_list.py
+++ b/DataStructures/singly_linked_list.py
@@ -76,14 +76,15 @@ class SinglyLinkedList:
         return elements
 
 
-# Usage example
-sll = SinglyLinkedList()
-sll.append(1)
-sll.append(2)
-sll.append(3)
-print("Original List:", sll.display())  # Output should be [1, 2, 3]
-sll.delete_node(2)
-print("After Deleting 2:", sll.display())  # Output should be [1, 3]
-print("Search for 3:", sll.search(3))  # Output should be True
-sll.reverse()
-print("Reversed List:", sll.display())  # Output should be [3, 1]
+if __name__ == "__main__":
+    # Usage example
+    sll = SinglyLinkedList()
+    sll.append(1)
+    sll.append(2)
+    sll.append(3)
+    print("Original List:", sll.display())  # Output should be [1, 2, 3]
+    sll.delete_node(2)
+    print("After Deleting 2:", sll.display())  # Output should be [1, 3]
+    print("Search for 3:", sll.search(3))  # Output should be True
+    sll.reverse()
+    print("Reversed List:", sll.display())  # Output should be [3, 1]


### PR DESCRIPTION
### Motivation
- Prevent side effects at import time by ensuring usage examples in data structure modules do not execute when the modules are imported.
- Make the modules safe to import from tests or other code without producing output or modifying state.

### Description
- Wrap top-level usage/demo code in each module with `if __name__ == "__main__":` to ensure examples only run when the file is executed directly.
- Updated the following files: `DataStructures/binary_search_tree.py`, `DataStructures/binary_tree.py`, `DataStructures/deque_based_queue.py`, `DataStructures/doubly_linked_list.py`, `DataStructures/list_based_stack.py`, and `DataStructures/singly_linked_list.py`.
- Adjusted indentation and moved example variable setup and `print` calls into the guarded blocks to preserve the original examples while eliminating import-time execution.

### Testing
- No automated tests were run as part of this change.
- Recommend running the project test suite with `pytest` to verify nothing else regresses after these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989521ec3dc832d8ff9b06f3afe63c1)