### PR TITLE
chore: require only uv (no manual Python install)

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -14,19 +14,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-
-      - name: Install test dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements-test.txt
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
 
       - name: Run tests with coverage
         run: |
-          python -m pytest tests/ --cov=. --cov-report=term --cov-report=html
+          uv run --python 3.10 --with-requirements requirements-test.txt pytest tests/ --cov=. --cov-report=term --cov-report=html
 
       - name: Upload coverage HTML report
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -19,22 +19,22 @@ This repository contains various demo projects and sample code that demonstrate 
 
 ## Installation
 
-It is recommended to use a Python virtual environment to isolate project dependencies.
+You only need to install **uv**. You do **not** need to install Python manually.
 
-### 1. Create and activate a virtual environment
+### 1. Create and activate a virtual environment (uv manages Python)
 
 **macOS/Linux:**
 
 ```bash
-python3 -m venv venv
-source venv/bin/activate
+uv venv --python 3.10
+source .venv/bin/activate
 ```
 
 **Windows:**
 
 ```bash
-python -m venv venv
-venv\Scripts\activate
+uv venv --python 3.10
+.venv\Scripts\activate
 ```
 
 ### 2. Install dependencies
@@ -42,20 +42,27 @@ venv\Scripts\activate
 To run the main functionality:
 
 ```bash
-pip install -r requirements.txt
+uv pip install -r requirements.txt
 ```
 
 To install test dependencies only:
 
 ```bash
-pip install -r requirements-test.txt
+uv pip install -r requirements-test.txt
+```
+
+### 3. Run tests directly with uv (without manual Python setup)
+
+```bash
+uv run --python 3.10 --with-requirements requirements-test.txt pytest tests/ --cov=. --cov-report=term --cov-report=html
 ```
 
 ---
 
 This project includes a GitHub Actions workflow for automated testing:
 
-- Installs Python and test dependencies
+- Installs uv
+- Uses uv-managed Python and test dependencies
 - Runs unit tests
 - Generates and uploads coverage reports
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -4,12 +4,24 @@
 
 ---
 
+## 前置條件
+
+只需安裝 `uv`，不需要另外手動安裝 Python。
+
+---
+
 ## 安裝測試相依套件
 
-請使用獨立的測試依賴檔案：
+如需建立本地 `.venv`，可先執行：
 
 ```bash
-pip install -r requirements-test.txt
+uv venv --python 3.10
+```
+
+再安裝測試相依套件：
+
+```bash
+uv pip install -r requirements-test.txt
 ```
 
 `requirements-test.txt` 應包含：
@@ -23,8 +35,10 @@ pytest-cov
 
 ## 執行測試（本地環境）
 
+建議直接使用 uv 執行（由 uv 管理 Python 與套件）：
+
 ```bash
-pytest --cov=. --cov-report=term --cov-report=html
+uv run --python 3.10 --with-requirements requirements-test.txt pytest tests/ --cov=. --cov-report=term --cov-report=html
 ```
 
 * 終端機將顯示測試覆蓋率摘要
@@ -65,8 +79,8 @@ pytest --cov=. --cov-report=term --cov-report=html
 * 觸發條件：push 或 PR 到 `main` 分支
 * 流程概要：
 
-  1. 安裝 Python 3.10
-  2. 安裝 `requirements-test.txt` 中的套件
+  1. 安裝 uv
+  2. 由 uv 自動提供 Python 3.10 與 `requirements-test.txt` 中的套件
   3. 執行 `pytest` 並產生覆蓋率報告
   4. 上傳 HTML 覆蓋率報告至 Artifacts
 


### PR DESCRIPTION
### Motivation
- Standardize the project to rely on `uv` for interpreter provisioning so users do not need to install Python manually.
- Ensure documentation and CI align with the new baseline where `uv` manages virtualenvs, interpreter version, and dependency installation.

### Description
- Updated `README.md` to state that only `uv` is required and replaced local setup commands with `uv venv --python 3.10`, `uv pip install -r ...`, and a `uv run --python 3.10 --with-requirements ... pytest ...` test example.
- Updated `TESTING.md` to reflect the same `uv`-centric instructions for creating a `.venv`, installing test deps, and running tests with `uv run`.
- Simplified the GitHub Actions workflow `.github/workflows/python-ci.yml` by removing `actions/setup-python` and explicit `pip` installs, adding `astral-sh/setup-uv@v5`, and running tests via `uv run --python 3.10 --with-requirements requirements-test.txt pytest ...`.
- Removed references to manual `python -m venv`, direct `pip install`, and `actions/setup-python` across the changed files.

### Testing
- Verified the changes by searching the modified files for `pip`, `setup-python`, and direct `python -m pytest` usages using `rg -n "\bpip\b|setup-python|python -m pytest|uv run|uv venv|不需要"`, which confirmed the intended replacements.
- Attempted to run tests locally with `uv run --python 3.10 --with-requirements requirements-test.txt pytest tests/ --cov=. --cov-report=term --cov-report=html`, but the run failed in this environment due to inability to reach PyPI (network/tunnel error) when fetching packages.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ac9acf1e8832dbb04199050ce6222)