### PR TITLE
Avoid import-time PIL in test_image_generator to fix pytest collection

### DIFF
--- a/Applications/test_image_generator.py
+++ b/Applications/test_image_generator.py
@@ -1,40 +1,38 @@
 import random
-from PIL import Image, ImageDraw
 
-# Define the image dimensions
-width, height = 3840, 1200
 
-# Create a new black image
-image = Image.new("RGB", (width, height), "black")
-draw = ImageDraw.Draw(image)
+def generate_test_image(width: int = 3840, height: int = 1200, grid_spacing: int = 120, edge_width: int = 1, noise_intensity: int = 20) -> None:
+    from PIL import Image, ImageDraw
 
-# Set edge width and grid spacing
-edge_width = 1
-grid_spacing = 120
+    # Create a new black image
+    image = Image.new("RGB", (width, height), "black")
+    draw = ImageDraw.Draw(image)
 
-# Draw the grid lines
-for x in range(0, width, grid_spacing):
-    draw.line([(x, 0), (x, height)], fill="white", width=edge_width)
-for y in range(0, height, grid_spacing):
-    draw.line([(0, y), (width, y)], fill="white", width=edge_width)
+    # Draw the grid lines
+    for x in range(0, width, grid_spacing):
+        draw.line([(x, 0), (x, height)], fill="white", width=edge_width)
+    for y in range(0, height, grid_spacing):
+        draw.line([(0, y), (width, y)], fill="white", width=edge_width)
 
-# Add noise to the image
-noise_intensity = 20
-pixels = image.load()
-for x in range(width):
-    for y in range(height):
-        noise = random.randint(-noise_intensity, noise_intensity)
-        r, g, b = pixels[x, y]
-        r = max(0, min(255, r + noise))
-        g = max(0, min(255, g + noise))
-        b = max(0, min(255, b + noise))
-        pixels[x, y] = (r, g, b)
+    # Add noise to the image
+    pixels = image.load()
+    for x in range(width):
+        for y in range(height):
+            noise = random.randint(-noise_intensity, noise_intensity)
+            r, g, b = pixels[x, y]
+            r = max(0, min(255, r + noise))
+            g = max(0, min(255, g + noise))
+            b = max(0, min(255, b + noise))
+            pixels[x, y] = (r, g, b)
 
-# Draw colored edges on the borders
-draw.rectangle((0, 0, width, edge_width), fill=(255, 0, 0))  # Top edge
-draw.rectangle((0, height - edge_width, width, height), fill=(0, 255, 0))  # Bottom edge
-draw.rectangle((0, 0, edge_width, height), fill=(0, 0, 255))  # Left edge
-draw.rectangle((width - edge_width, 0, width, height), fill=(255, 255, 0))  # Right edge
+    # Draw colored edges on the borders
+    draw.rectangle((0, 0, width, edge_width), fill=(255, 0, 0))  # Top edge
+    draw.rectangle((0, height - edge_width, width, height), fill=(0, 255, 0))  # Bottom edge
+    draw.rectangle((0, 0, edge_width, height), fill=(0, 0, 255))  # Left edge
+    draw.rectangle((width - edge_width, 0, width, height), fill=(255, 255, 0))  # Right edge
 
-# Save the image
-image.save(f"panel_test_{width}x{height}.png")
+    image.save(f"panel_test_{width}x{height}.png")
+
+
+if __name__ == "__main__":
+    generate_test_image()


### PR DESCRIPTION
### Motivation
- `Applications/test_image_generator.py` was executed at import time and did `from PIL import ...`, which caused `pytest` collection to fail in environments without Pillow due to `ModuleNotFoundError`.
- The intent is to keep the script runnable as a standalone generator while preventing import-side effects during test discovery.

### Description
- Refactored the script so image creation logic is encapsulated in a `generate_test_image(...)` function. 
- Moved `PIL` imports inside `generate_test_image` to avoid requiring Pillow at module import time. 
- Added an `if __name__ == "__main__":` entrypoint to preserve the original script behavior when executed directly. 
- Updated `Applications/test_image_generator.py` accordingly to remove import-time side effects.

### Testing
- Running `pytest -q` before the change failed during collection with `ModuleNotFoundError: No module named 'PIL'`.
- After the change, `pytest -q` passes with `32 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698acdd2f3f0832db3cf75f2544e6395)