### PR TITLE
chore: restore README formatting; validate binary_search and GradeSystem; add tests

### DIFF
--- a/Algorithms/search_algorithms.py
+++ b/Algorithms/search_algorithms.py
@@ -14,6 +14,11 @@ def linear_search(item, items):
     return None  # Item not found
 
 
+def _is_non_decreasing(items):
+    """Return True when items are sorted in non-decreasing order."""
+    return all(items[index] <= items[index + 1] for index in range(len(items) - 1))
+
+
 def binary_search(item, items):
     """
     Performs a binary search to find the index of an item in a sorted list.
@@ -23,7 +28,13 @@ def binary_search(item, items):
 
     Returns:
         int or None: The index of the item if found, None otherwise.
+
+    Raises:
+        ValueError: If ``items`` is not sorted in non-decreasing order.
     """
+    if not _is_non_decreasing(items):
+        raise ValueError("binary_search requires a sorted list in non-decreasing order")
+
     first, last = 0, len(items) - 1
     while first <= last:
         mid = (first + last) // 2

--- a/Applications/AlgorithmsLab/GradeSystem.py
+++ b/Applications/AlgorithmsLab/GradeSystem.py
@@ -34,6 +34,9 @@ class GradeSystem:
 
     def insert_grade(self, data):
         student_data = data.split()
+        if len(student_data) < 3 or len(student_data[1:]) % 2 != 0:
+            raise ValueError("資料格式錯誤，請使用: 學號 科目 成績 [科目 成績 ...]")
+
         student_no = student_data[0]
         subjects = student_data[1:]
         subject_grade = {}
@@ -51,22 +54,25 @@ class GradeSystem:
 class GradeSystemDriver:
     def __init__(self):
         self.grade_system = GradeSystem()
-        self.file_path = "grade2.txt"
+        self.file_path = os.path.join(os.path.dirname(__file__), "grade2.txt")
 
     def load_data(self):
         if os.path.exists(self.file_path):
             with open(self.file_path, "r", encoding="utf-8") as file:
                 for line in file:
-                    self.grade_system.insert_grade(line.strip())
+                    line = line.strip()
+                    if not line:
+                        continue
+                    self.grade_system.insert_grade(line)
             print(f"已從 {self.file_path} 匯入成績資料")
 
     def save_data(self):
         with open(self.file_path, "w", encoding="utf-8") as file:
             for student_no, subject_scores in self.grade_system.student_grade.items():
-                data = [
-                    f"{student_no} {subject} {score}"
-                    for subject, score in subject_scores.items()
-                ]
+                data = [student_no]
+                for subject, score in subject_scores.items():
+                    data.extend([subject, str(score)])
+
                 file.write(" ".join(data) + "\n")
 
     def run(self):
@@ -104,8 +110,11 @@ class GradeSystemDriver:
                 student_data = input(
                     "請輸入學生學號及科目成績 (例如:97531 DS 80 DM 80 LA 80): "
                 )
-                self.grade_system.insert_grade(student_data)
-                print("新增成功!")
+                try:
+                    self.grade_system.insert_grade(student_data)
+                    print("新增成功!")
+                except ValueError as e:
+                    print(e)
             elif choice == "4":
                 student_id = input("請輸入學號:")
                 self.grade_system.delete_grade(student_id)

--- a/tests/test_grade_system.py
+++ b/tests/test_grade_system.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+import pytest
+
+from Applications.AlgorithmsLab.GradeSystem import GradeSystem, GradeSystemDriver
+
+
+def test_insert_grade_rejects_invalid_input():
+    grade_system = GradeSystem()
+
+    with pytest.raises(ValueError):
+        grade_system.insert_grade("97531 DS")
+
+    with pytest.raises(ValueError):
+        grade_system.insert_grade("97531 DS 80 DM")
+
+
+def test_save_data_persists_one_student_per_line(tmp_path):
+    driver = GradeSystemDriver()
+    driver.file_path = str(tmp_path / "grade2.txt")
+
+    driver.grade_system.insert_grade("97531 DS 80 DM 81")
+    driver.grade_system.insert_grade("97532 DS 90")
+
+    driver.save_data()
+
+    content = Path(driver.file_path).read_text(encoding="utf-8").strip().splitlines()
+
+    assert content == ["97531 DS 80 DM 81", "97532 DS 90"]
+
+
+def test_load_data_skips_blank_lines(tmp_path):
+    data_file = tmp_path / "grade2.txt"
+    data_file.write_text("97531 DS 80 DM 81\n\n97532 DS 90\n", encoding="utf-8")
+
+    driver = GradeSystemDriver()
+    driver.file_path = str(data_file)
+
+    driver.load_data()
+
+    assert driver.grade_system.search_grade("97531", "DM") == 81
+    assert driver.grade_system.search_grade("97532", "DS") == 90

--- a/tests/test_search_algorithms.py
+++ b/tests/test_search_algorithms.py
@@ -1,4 +1,6 @@
-from Algorithms.search_algorithms import linear_search, binary_search
+import pytest
+
+from Algorithms.search_algorithms import binary_search, linear_search
 
 
 def test_linear_search():
@@ -13,3 +15,8 @@ def test_binary_search():
     assert binary_search(30, items) == 2
     assert binary_search(100, items) is None
     assert binary_search(10, items) == 0
+
+
+def test_binary_search_rejects_unsorted_input():
+    with pytest.raises(ValueError):
+        binary_search(30, [10, 50, 30, 40])


### PR DESCRIPTION
### Motivation
- Restore `README.md` to remove an unintended formatting change.
- Ensure `binary_search` fails fast on unsorted input to avoid silent incorrect results.
- Harden `GradeSystem` input handling and file I/O so data round-trips reliably and the CLI does not crash on malformed input.
- Add tests to prevent regressions for the new validation and persistence behaviors.

### Description
- Add `_is_non_decreasing` and make `binary_search` raise `ValueError` when `items` is not sorted in non-decreasing order.
- Validate input in `GradeSystem.insert_grade` and raise `ValueError` for malformed input.
- Update `GradeSystemDriver` to use `os.path.join(os.path.dirname(__file__), "grade2.txt")` for `file_path`, skip blank lines in `load_data`, and write one student per line in `save_data`.
- Catch `ValueError` in the interactive insert flow to avoid crashing on bad user input.
- Add `tests/test_grade_system.py` and update `tests/test_search_algorithms.py` to cover the new validation and persistence behaviors, and restore minor README formatting (removed extra blank lines) without content changes.

### Testing
- Ran `pytest -q` and all tests passed (`36 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698acf29ad8c832d96d2dc1f6751169b)